### PR TITLE
fix: use our tendermint-rs fork directly instead of patching

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,13 +6,10 @@ members = ["proto", "types", "rpc"]
 celestia-proto = { version = "0.1.0", path = "proto" }
 celestia-types = { version = "0.1.0", path = "types" }
 nmt-rs = { git = "https://github.com/eigerco/nmt-rs.git", rev = "5146800" }
-tendermint = "0.32"
-tendermint-proto = "0.32"
-
-[patch.crates-io]
-# `cosmrs` is using terndermint from crates.io, so we patch it with ours
 tendermint = { git = "https://github.com/eigerco/celestia-tendermint-rs.git", rev = "dbb4434" }
 tendermint-proto = { git = "https://github.com/eigerco/celestia-tendermint-rs.git", rev = "dbb4434" }
+
+[patch.'https://github.com/eigerco/celestia-tendermint-rs.git']
 # Uncomment to apply local changes
 #tendermint = { path = "../celestia-tendermint-rs/tendermint" }
 #tendermint-proto = { path = "../celestia-tendermint-rs/proto" }


### PR DESCRIPTION
Fixes #37 