### PR TITLE
Fix docker for apple silicon macs

### DIFF
--- a/ci/docker-compose.yml
+++ b/ci/docker-compose.yml
@@ -1,6 +1,7 @@
 services:
   validator:
     image: validator
+    platform: "linux/amd64"
     build:
       context: .
       dockerfile: Dockerfile.validator
@@ -9,6 +10,7 @@ services:
 
   bridge:
     image: bridge
+    platform: "linux/amd64"
     build:
       context: .
       dockerfile: Dockerfile.bridge

--- a/tools/gen_auth_tokens.sh
+++ b/tools/gen_auth_tokens.sh
@@ -27,12 +27,16 @@ generate_token() {
 }
 
 write_token() {
-  local auth_level=$(echo "$1" | tr '[:lower:]' '[:upper:]')
+  local auth_level="$1" $(echo "$1" | tr '[:lower:]' '[:upper:]')
   local token="$2"
+
+  local auth_level=$(echo "$auth_level" | tr '[:lower:]' '[:upper:]')
 
   local var_name="CELESTIA_NODE_AUTH_TOKEN_${auth_level}"
 
-  sed -i'' -e "s/.*$var_name.*/$var_name=$token/" "$DOTENV"
+  sed -i '.bak' -e "s/.*$var_name.*/$var_name=$token/" "$DOTENV"
+  rm "$DOTENV.bak" # there's no compatible way to tell sed not to do a backup file
+                   # accept it and remove the file afterwards
 }
 
 main() {

--- a/tools/gen_auth_tokens.sh
+++ b/tools/gen_auth_tokens.sh
@@ -27,16 +27,14 @@ generate_token() {
 }
 
 write_token() {
-  local auth_level="$1" $(echo "$1" | tr '[:lower:]' '[:upper:]')
+  local auth_level="$1"
   local token="$2"
 
   local auth_level=$(echo "$auth_level" | tr '[:lower:]' '[:upper:]')
 
   local var_name="CELESTIA_NODE_AUTH_TOKEN_${auth_level}"
 
-  sed -i '.bak' -e "s/.*$var_name.*/$var_name=$token/" "$DOTENV"
-  rm "$DOTENV.bak" # there's no compatible way to tell sed not to do a backup file
-                   # accept it and remove the file afterwards
+  ex "+%s/.*$var_name.*/$var_name=$token/" -scwq "$DOTENV"
 }
 
 main() {

--- a/tools/gen_auth_tokens.sh
+++ b/tools/gen_auth_tokens.sh
@@ -34,7 +34,10 @@ write_token() {
 
   local var_name="CELESTIA_NODE_AUTH_TOKEN_${auth_level}"
 
-  ex "+%s/.*$var_name.*/$var_name=$token/" -scwq "$DOTENV"
+  sed -i.bak "s/.*$var_name.*/$var_name=$token/" "$DOTENV"
+  # there's no compatible way to tell sed not to do a backup file
+  # accept it and remove the file afterwards
+  rm "$DOTENV.bak"
 }
 
 main() {

--- a/tools/gen_auth_tokens.sh
+++ b/tools/gen_auth_tokens.sh
@@ -30,7 +30,7 @@ write_token() {
   local auth_level="$1"
   local token="$2"
 
-  local auth_level=$(echo "$auth_level" | tr '[:lower:]' '[:upper:]')
+  auth_level="$(echo "$auth_level" | tr '[:lower:]' '[:upper:]')"
 
   local var_name="CELESTIA_NODE_AUTH_TOKEN_${auth_level}"
 

--- a/tools/gen_auth_tokens.sh
+++ b/tools/gen_auth_tokens.sh
@@ -27,12 +27,12 @@ generate_token() {
 }
 
 write_token() {
-  local auth_level="$1"
+  local auth_level=$(echo "$1" | tr '[:lower:]' '[:upper:]')
   local token="$2"
 
-  local var_name="CELESTIA_NODE_AUTH_TOKEN_${auth_level^^}"
+  local var_name="CELESTIA_NODE_AUTH_TOKEN_${auth_level}"
 
-  sed -i "s/.*$var_name.*/$var_name=$token/" "$DOTENV"
+  sed -i'' -e "s/.*$var_name.*/$var_name=$token/" "$DOTENV"
 }
 
 main() {


### PR DESCRIPTION
Explicitly set platform in docker compose, otherwise docker tries to start it as linux/arm64 and musl is unhappy. https://stackoverflow.com/questions/71040681/qemu-x86-64-could-not-open-lib64-ld-linux-x86-64-so-2-no-such-file-or-direc

`upper=${lower^^}` syntax exists from bash 4.0, macos has 3.2. Replace it with `tr`. https://unix.stackexchange.com/questions/51983/how-to-uppercase-the-command-line-argument

Mac's sed is more BSD-like and ~~`-i` suffix cannot be ommited when empty.~~ there's no command that works for both GNU and Mac's BSD-like *and* doesn't create a backup file. 
  https://stackoverflow.com/questions/4247068/sed-command-with-i-option-failing-on-mac-but-works-on-linux

This all should be portable enough to work on linux and recent macs .