### PR TITLE
chore: trim the features of workspace dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,10 +5,10 @@ members = ["celestia", "node", "proto", "rpc", "types"]
 [workspace.dependencies]
 celestia-node = { version = "0.1.0", path = "node" }
 celestia-proto = { version = "0.1.0", path = "proto" }
-celestia-rpc = { version = "0.1.0", path = "rpc" }
-celestia-types = { version = "0.1.0", path = "types" }
+celestia-rpc = { version = "0.1.0", path = "rpc", default-features = false }
+celestia-types = { version = "0.1.0", path = "types", default-features = false }
 nmt-rs = { git = "https://github.com/Sovereign-Labs/nmt-rs.git", rev = "d821332" }
-tendermint = { git = "https://github.com/eigerco/celestia-tendermint-rs.git", rev = "1f8b574" }
+tendermint = { git = "https://github.com/eigerco/celestia-tendermint-rs.git", rev = "1f8b574", default-features = false }
 tendermint-proto = { git = "https://github.com/eigerco/celestia-tendermint-rs.git", rev = "1f8b574" }
 
 [patch.'https://github.com/eigerco/celestia-tendermint-rs.git']

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -36,7 +36,7 @@ wasm-bindgen-futures = "0.4.37"
 
 [dev-dependencies]
 bytes = "1.4.0"
-celestia-rpc = { workspace = true }
+celestia-rpc = { workspace = true, features = ["p2p"] }
 celestia-types = { workspace = true, features = ["test-utils"] }
 celestia-node = { workspace = true, features = ["test-utils"] }
 dotenvy = "0.15.7"

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -19,7 +19,13 @@ jsonrpsee = { version = "0.20", features = ["http-client", "ws-client"] }
 anyhow = "1.0.71"
 dotenvy = "0.15.7"
 futures = "0.3.28"
-libp2p = { version = "0.52.3", features = ["tokio", "macros", "tcp", "noise", "yamux"] }
+libp2p = { version = "0.52.3", features = [
+  "tokio",
+  "macros",
+  "tcp",
+  "noise",
+  "yamux",
+] }
 rand = "0.8.5"
 tokio = { version = "1.32.0", features = ["rt", "macros"] }
 tracing = "0.1.37"

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -21,7 +21,7 @@ ruint = { version = "1.8.0", features = ["serde"] }
 serde = { version = "1.0.164", features = ["derive"] }
 serde_repr = { version = "0.1", optional = true }
 sha2 = "0.10.7"
-tendermint = { workspace = true }
+tendermint = { workspace = true, features = ["std", "rust-crypto"] }
 tendermint-proto = { workspace = true }
 thiserror = "1.0.40"
 
@@ -34,4 +34,4 @@ serde_json = "1.0.97"
 [features]
 default = ["p2p"]
 p2p = ["dep:libp2p-identity", "dep:multiaddr", "dep:serde_repr"]
-test-utils = ["tendermint/rust-crypto", "dep:ed25519-consensus", "dep:rand"]
+test-utils = ["dep:ed25519-consensus", "dep:rand"]


### PR DESCRIPTION
currently doing this still pulls in all libp2p dependencies as `celestia-rpc` depends on `celestia-types` with default features on

```
celestia-rpc = { git = "...", default-features = false }
```