### PR TITLE
fix(node/syncer): Stop fetching header when all peers disconnected

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,8 @@ jobs:
 
   test-wasm:
     runs-on: ubuntu-latest
+    env:
+      WASM_BINDGEN_TEST_TIMEOUT: 60
     steps:
     - uses: actions/checkout@v1
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -384,6 +384,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "backoff"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1"
+dependencies = [
+ "futures-core",
+ "getrandom 0.2.10",
+ "instant",
+ "pin-project-lite",
+ "rand 0.8.5",
+ "tokio",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -571,6 +585,7 @@ name = "celestia-node"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "backoff",
  "bytes",
  "celestia-node",
  "celestia-proto",
@@ -594,6 +609,7 @@ dependencies = [
  "tendermint-proto",
  "thiserror",
  "tokio",
+ "tokio-util",
  "tracing",
  "wasm-bindgen-futures",
 ]
@@ -1752,6 +1768,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
  "cfg-if",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]

--- a/celestia/src/native.rs
+++ b/celestia/src/native.rs
@@ -60,10 +60,10 @@ pub async fn run() -> Result<()> {
     } else {
         SledStore::new(network_id.clone()).await?
     };
-    info!(
-        "Initialised store with head height: {:?}",
-        store.head_height().await
-    );
+
+    if let Ok(store_height) = store.head_height().await {
+        info!("Initialised store with head height: {store_height}");
+    }
 
     let node = Node::new(NodeConfig {
         network_id,

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -27,10 +27,12 @@ rand = "0.8.5"
 smallvec = { version = "1.11.1", features = ["union", "const_generics"] }
 thiserror = "1.0.48"
 tokio = { version = "1.32.0", features = ["macros", "sync"] }
+tokio-util = "0.7.9"
 tracing = "0.1.37"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 directories = "5.0.1"
+backoff = { version = "0.4.0", features = ["tokio"] }
 # Upgrading this dependency invalidates existing persistent dbs.
 # Those can be restored by migrating between versions:
 # https://docs.rs/sled/latest/sled/struct.Db.html#examples-1
@@ -47,6 +49,7 @@ libp2p = { version = "0.52.3", features = [
 ] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
+backoff = { version = "0.4.0", features = ["wasm-bindgen"] }
 getrandom = { version = "0.2.10", features = ["js"] }
 wasm-bindgen-futures = "0.4.37"
 gloo-timers = { version = "0.3.0", features = ["futures"] }

--- a/node/src/executor.rs
+++ b/node/src/executor.rs
@@ -78,8 +78,6 @@ mod imp {
     use std::task::{Context, Poll};
     use std::time::Duration;
 
-    pub(crate) use gloo_timers::future::sleep;
-
     pub(crate) fn spawn<F>(future: F)
     where
         F: Future<Output = ()> + Send + 'static,
@@ -106,6 +104,7 @@ mod imp {
     #[derive(Debug)]
     pub(crate) struct Elapsed;
 
+    #[allow(dead_code)]
     pub(crate) fn timeout<F>(duration: Duration, future: F) -> Timeout<F>
     where
         F: Future,
@@ -117,6 +116,12 @@ mod imp {
             value: future,
             delay,
         }
+    }
+
+    pub(crate) async fn sleep(duration: Duration) {
+        let millis = u32::try_from(duration.as_millis().max(1)).unwrap_or(u32::MAX);
+        let delay = SendWrapper::new(TimeoutFuture::new(millis));
+        delay.await;
     }
 
     #[pin_project]

--- a/node/src/executor.rs
+++ b/node/src/executor.rs
@@ -16,7 +16,10 @@ impl swarm::Executor for Executor {
     }
 }
 
-/// Spawn a task and that can be stopped by the `cancelation_token`.
+/// Spawn a cancellable task.
+///
+/// This will cancel the task in the highest layer and should not be used
+/// if cancellation must happen in a point.
 pub(crate) fn spawn_cancellable<F>(cancelation_token: CancellationToken, future: F)
 where
     F: Future<Output = ()> + Send + 'static,

--- a/node/src/p2p.rs
+++ b/node/src/p2p.rs
@@ -213,6 +213,10 @@ where
         self.peer_tracker_info_watcher.clone()
     }
 
+    pub fn peer_tracker_info(&self) -> watch::Ref<PeerTrackerInfo> {
+        self.peer_tracker_info_watcher.borrow()
+    }
+
     pub async fn init_header_sub(&self, head: ExtendedHeader) -> Result<()> {
         let (tx, rx) = oneshot::channel();
 

--- a/node/src/syncer.rs
+++ b/node/src/syncer.rs
@@ -179,11 +179,6 @@ where
     }
 
     async fn run(&mut self) {
-        if let Ok(store_height) = self.store.head_height().await {
-            info!("Setting initial subjective head to {store_height}");
-            self.subjective_head_height = Some(store_height);
-        }
-
         loop {
             if self.cancellation_token.is_cancelled() {
                 break;
@@ -220,20 +215,8 @@ where
                     self.report().await;
                 }
                 Ok(network_head_height) = &mut try_init_result => {
-                    match self.subjective_head_height {
-                        Some(height) if network_head_height > height => {
-                            info!("Updating subjective head to {network_head_height}");
-                            self.subjective_head_height = Some(network_head_height);
-                        }
-                        Some(height) if network_head_height == height => {}
-                        Some(height) => {
-                            warn!("Network head ({network_head_height}) is smaller than the subjective head ({height})");
-                        }
-                        None => {
-                            info!("Setting initial subjective head to {network_head_height}");
-                            self.subjective_head_height = Some(network_head_height);
-                        }
-                    }
+                    info!("Setting initial subjective head to {network_head_height}");
+                    self.subjective_head_height = Some(network_head_height);
                     break;
                 }
                 Some(cmd) = self.cmd_rx.recv() => {

--- a/node/src/syncer.rs
+++ b/node/src/syncer.rs
@@ -20,6 +20,7 @@ use crate::utils::OneshotSenderExt;
 type Result<T, E = SyncerError> = std::result::Result<T, E>;
 
 const MAX_HEADERS_IN_BATCH: u64 = 512;
+const TRY_INIT_BACKOFF_MAX_INTERVAL: Duration = Duration::from_secs(60);
 
 #[derive(Debug, thiserror::Error)]
 pub enum SyncerError {
@@ -311,7 +312,7 @@ where
 
         let fut = async move {
             let mut backoff = ExponentialBackoffBuilder::default()
-                .with_max_interval(Duration::from_secs(60))
+                .with_max_interval(TRY_INIT_BACKOFF_MAX_INTERVAL)
                 .with_max_elapsed_time(None)
                 .build();
 

--- a/node/src/syncer.rs
+++ b/node/src/syncer.rs
@@ -12,7 +12,7 @@ use tokio::sync::{mpsc, oneshot, watch};
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, info, info_span, instrument, warn, Instrument};
 
-use crate::executor::{spawn, spawn_cancellable, Interval};
+use crate::executor::{sleep, spawn, spawn_cancellable, Interval};
 use crate::p2p::{P2p, P2pError};
 use crate::store::{Store, StoreError};
 use crate::utils::OneshotSenderExt;
@@ -244,6 +244,7 @@ where
         let mut report_interval = Interval::new(Duration::from_secs(60)).await;
         let peer_tracker_info_watcher = self.p2p.peer_tracker_info_watcher();
 
+        self.fetch_next_batch().await;
         self.report().await;
 
         loop {
@@ -326,7 +327,7 @@ where
                             .expect("backoff never stops retrying");
 
                         warn!("Intialization of subjective head failed: {e}. Trying again in {sleep_dur:?}.");
-                        tokio::time::sleep(sleep_dur).await;
+                        sleep(sleep_dur).await;
                     }
                 }
             }

--- a/node/src/syncer.rs
+++ b/node/src/syncer.rs
@@ -413,7 +413,7 @@ where
         }
 
         if self.p2p.peer_tracker_info().num_connected_peers == 0 {
-            // No connected peers. We can do the request.
+            // No connected peers. We can't do the request.
             // This will be recovered by `run`.
             return;
         }

--- a/node/src/test_utils.rs
+++ b/node/src/test_utils.rs
@@ -75,6 +75,13 @@ impl MockP2pHandle {
         });
     }
 
+    pub fn announce_all_peers_disconnected(&self) {
+        self.peer_tracker_tx.send_modify(|info| {
+            info.num_connected_peers = 0;
+            info.num_connected_trusted_peers = 0;
+        });
+    }
+
     pub fn announce_new_head(&self, header: ExtendedHeader) {
         self.header_sub_tx.send_replace(Some(header));
     }


### PR DESCRIPTION
* Implemented `connecting_event_loop` and `connected_event_loop`
* In the `connecting_event_loop` Syncer waits for a trusted peer to connect and fetches the HEAD, then continues with the `connected_event_loop`.
* In the `connected_event_loop` Syncer starts the syncing process. If all peers disconnected, it moves back to the `connecting_event_loop`
* Added exponensial backoff for retrying the `try_init`
* Added a way to cancel spawned tasks in Syncer.