### PR TITLE
feat(rpc): create wrappers for jsonrpsee clients

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -343,9 +343,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.73"
+version = "0.1.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc00ceb34980c03614e35a3a4e218276a0a824e911d07651cd0d858a51e8c0f0"
+checksum = "a66537f1bb974b254c98ed142ff995236e81b9d0fe4db0575f46612cb15eb0f9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -625,6 +625,7 @@ name = "celestia-rpc"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "celestia-types",
  "dotenvy",
  "futures",

--- a/celestia/src/native.rs
+++ b/celestia/src/native.rs
@@ -5,8 +5,8 @@ use std::time::Duration;
 use anyhow::{bail, Context, Result};
 use celestia_node::node::{Node, NodeConfig};
 use celestia_node::store::SledStore;
-use celestia_rpc::client::WsClient;
 use celestia_rpc::prelude::*;
+use celestia_rpc::Client;
 use celestia_types::hash::Hash;
 use clap::{Parser, ValueEnum};
 use libp2p::{identity, multiaddr::Protocol, Multiaddr};
@@ -142,7 +142,7 @@ async fn network_bootnodes(network: Network) -> Result<Vec<Multiaddr>> {
 /// Get the address of the local bridge node
 async fn fetch_bridge_multiaddrs(ws_url: &str) -> Result<Vec<Multiaddr>> {
     let auth_token = env::var("CELESTIA_NODE_AUTH_TOKEN_ADMIN")?;
-    let client = WsClient::new(ws_url, Some(&auth_token)).await?;
+    let client = Client::new(ws_url, Some(&auth_token)).await?;
     let bridge_info = client.p2p_info().await?;
 
     info!("bridge id: {:?}", bridge_info.id);

--- a/celestia/src/native.rs
+++ b/celestia/src/native.rs
@@ -5,6 +5,7 @@ use std::time::Duration;
 use anyhow::{bail, Context, Result};
 use celestia_node::node::{Node, NodeConfig};
 use celestia_node::store::SledStore;
+use celestia_rpc::client::WsClient;
 use celestia_rpc::prelude::*;
 use celestia_types::hash::Hash;
 use clap::{Parser, ValueEnum};
@@ -141,7 +142,7 @@ async fn network_bootnodes(network: Network) -> Result<Vec<Multiaddr>> {
 /// Get the address of the local bridge node
 async fn fetch_bridge_multiaddrs(ws_url: &str) -> Result<Vec<Multiaddr>> {
     let auth_token = env::var("CELESTIA_NODE_AUTH_TOKEN_ADMIN")?;
-    let client = celestia_rpc::client::new_websocket(ws_url, Some(&auth_token)).await?;
+    let client = WsClient::new(ws_url, Some(&auth_token)).await?;
     let bridge_info = client.p2p_info().await?;
 
     info!("bridge id: {:?}", bridge_info.id);

--- a/node/tests/node.rs
+++ b/node/tests/node.rs
@@ -8,7 +8,7 @@ use celestia_node::{
     store::InMemoryStore,
     test_utils::{test_node_config, test_node_config_with_keypair},
 };
-use celestia_rpc::prelude::*;
+use celestia_rpc::{client::WsClient, prelude::*};
 use libp2p::{identity, multiaddr::Protocol, Multiaddr, PeerId};
 use tokio::time::sleep;
 
@@ -18,9 +18,7 @@ async fn fetch_bridge_info() -> (PeerId, Multiaddr) {
     let _ = dotenvy::dotenv();
 
     let auth_token = env::var("CELESTIA_NODE_AUTH_TOKEN_ADMIN").unwrap();
-    let client = celestia_rpc::client::new_websocket(WS_URL, Some(&auth_token))
-        .await
-        .unwrap();
+    let client = WsClient::new(WS_URL, Some(&auth_token)).await.unwrap();
     let bridge_info = client.p2p_info().await.unwrap();
 
     let mut ma = bridge_info

--- a/node/tests/node.rs
+++ b/node/tests/node.rs
@@ -8,7 +8,7 @@ use celestia_node::{
     store::InMemoryStore,
     test_utils::{test_node_config, test_node_config_with_keypair},
 };
-use celestia_rpc::{client::WsClient, prelude::*};
+use celestia_rpc::{prelude::*, Client};
 use libp2p::{identity, multiaddr::Protocol, Multiaddr, PeerId};
 use tokio::time::sleep;
 
@@ -18,7 +18,7 @@ async fn fetch_bridge_info() -> (PeerId, Multiaddr) {
     let _ = dotenvy::dotenv();
 
     let auth_token = env::var("CELESTIA_NODE_AUTH_TOKEN_ADMIN").unwrap();
-    let client = WsClient::new(WS_URL, Some(&auth_token)).await.unwrap();
+    let client = Client::new(WS_URL, Some(&auth_token)).await.unwrap();
     let bridge_info = client.p2p_info().await.unwrap();
 
     let mut ma = bridge_info

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 license = "Apache-2.0"
 
 [dependencies]
+async-trait = "0.1"
 celestia-types = { workspace = true }
 jsonrpsee = { version = "0.20", features = ["client-core", "macros"] }
 serde = { version = "1.0.188", features = ["derive"] }

--- a/rpc/src/client.rs
+++ b/rpc/src/client.rs
@@ -1,42 +1,146 @@
-pub use self::imp::*;
+//! Clients for the celestia Json-RPC.
+//!
+//! This module aims to provide a convenient way to create a Json-RPC clients. If
+//! you need more configuration options and / or some custom client you can create
+//! one using [`jsonrpsee`] crate directly.
+
+#[cfg(not(target_arch = "wasm32"))]
+pub use self::imp::{HttpClient, WsClient};
 
 #[cfg(not(target_arch = "wasm32"))]
 mod imp {
     use crate::Result;
     use http::{header, HeaderValue};
-    use jsonrpsee::http_client::{HeaderMap, HttpClient, HttpClientBuilder};
-    use jsonrpsee::ws_client::{WsClient, WsClientBuilder};
+    use jsonrpsee::http_client::{HeaderMap, HttpClient as JrpcHttpClient, HttpClientBuilder};
+    use jsonrpsee::ws_client::{WsClient as JrpcWsClient, WsClientBuilder};
 
-    pub fn new_http(conn_str: &str, auth_token: Option<&str>) -> Result<HttpClient> {
-        let mut headers = HeaderMap::new();
-
-        if let Some(token) = auth_token {
-            let val = HeaderValue::from_str(&format!("Bearer {token}"))?;
-            headers.insert(header::AUTHORIZATION, val);
-        }
-
-        let client = HttpClientBuilder::default()
-            .set_headers(headers)
-            .build(conn_str)?;
-
-        Ok(client)
+    /// Json RPC client using http protocol.
+    pub struct HttpClient {
+        inner: JrpcHttpClient,
     }
 
-    pub async fn new_websocket(conn_str: &str, auth_token: Option<&str>) -> Result<WsClient> {
-        let mut headers = HeaderMap::new();
+    impl HttpClient {
+        /// Create a new http client.
+        pub fn new(conn_str: &str, auth_token: Option<&str>) -> Result<Self> {
+            let mut headers = HeaderMap::new();
 
-        if let Some(token) = auth_token {
-            let val = HeaderValue::from_str(&format!("Bearer {token}"))?;
-            headers.insert(header::AUTHORIZATION, val);
+            if let Some(token) = auth_token {
+                let val = HeaderValue::from_str(&format!("Bearer {token}"))?;
+                headers.insert(header::AUTHORIZATION, val);
+            }
+
+            let client = HttpClientBuilder::default()
+                .set_headers(headers)
+                .build(conn_str)?;
+
+            Ok(Self { inner: client })
         }
-
-        let client = WsClientBuilder::default()
-            .set_headers(headers)
-            .build(conn_str)
-            .await?;
-
-        Ok(client)
     }
+
+    /// Json RPC client using websockets protocol.
+    pub struct WsClient {
+        inner: JrpcWsClient,
+    }
+
+    impl WsClient {
+        /// Create a new websocket client.
+        pub async fn new(conn_str: &str, auth_token: Option<&str>) -> Result<Self> {
+            let mut headers = HeaderMap::new();
+
+            if let Some(token) = auth_token {
+                let val = HeaderValue::from_str(&format!("Bearer {token}"))?;
+                headers.insert(header::AUTHORIZATION, val);
+            }
+
+            let client = WsClientBuilder::default()
+                .set_headers(headers)
+                .build(conn_str)
+                .await?;
+
+            Ok(Self { inner: client })
+        }
+    }
+
+    /// Implements `ClientT` and `SubscriptionClientT` by delegating calls to $typ::$target.
+    macro_rules! impl_jsonrpc_client_delegate {
+        ($typ:ty, $target:ident) => {
+            #[::async_trait::async_trait]
+            impl ::jsonrpsee::core::client::ClientT for $typ {
+                async fn notification<Params>(
+                    &self,
+                    method: &str,
+                    params: Params,
+                ) -> ::std::result::Result<(), ::jsonrpsee::core::Error>
+                where
+                    Params: ::jsonrpsee::core::traits::ToRpcParams + ::std::marker::Send,
+                {
+                    self.$target.notification(method, params).await
+                }
+
+                async fn request<R, Params>(
+                    &self,
+                    method: &str,
+                    params: Params,
+                ) -> ::std::result::Result<R, ::jsonrpsee::core::Error>
+                where
+                    R: ::serde::de::DeserializeOwned,
+                    Params: ::jsonrpsee::core::traits::ToRpcParams + ::std::marker::Send,
+                {
+                    self.$target.request(method, params).await
+                }
+
+                async fn batch_request<'a, R>(
+                    &self,
+                    batch: ::jsonrpsee::core::params::BatchRequestBuilder<'a>,
+                ) -> ::std::result::Result<
+                    ::jsonrpsee::core::client::BatchResponse<'a, R>,
+                    ::jsonrpsee::core::Error,
+                >
+                where
+                    R: ::serde::de::DeserializeOwned + ::std::fmt::Debug + 'a,
+                {
+                    self.$target.batch_request(batch).await
+                }
+            }
+
+            #[::async_trait::async_trait]
+            impl ::jsonrpsee::core::client::SubscriptionClientT for $typ {
+                async fn subscribe<'a, N, Params>(
+                    &self,
+                    subscribe_method: &'a str,
+                    params: Params,
+                    unsubscribe_method: &'a str,
+                ) -> ::std::result::Result<
+                    ::jsonrpsee::core::client::Subscription<N>,
+                    ::jsonrpsee::core::Error,
+                >
+                where
+                    Params: ::jsonrpsee::core::traits::ToRpcParams + ::std::marker::Send,
+                    N: ::serde::de::DeserializeOwned,
+                {
+                    self.$target
+                        .subscribe(subscribe_method, params, unsubscribe_method)
+                        .await
+                }
+
+                async fn subscribe_to_method<'a, N>(
+                    &self,
+                    method: &'a str,
+                ) -> ::std::result::Result<
+                    ::jsonrpsee::core::client::Subscription<N>,
+                    ::jsonrpsee::core::Error,
+                >
+                where
+                    N: ::serde::de::DeserializeOwned,
+                {
+                    self.$target.subscribe_to_method(method).await
+                }
+            }
+        };
+    }
+
+    impl_jsonrpc_client_delegate!(HttpClient, inner);
+    impl_jsonrpc_client_delegate!(WsClient, inner);
 }
 
 #[cfg(target_arch = "wasm32")]

--- a/rpc/src/client.rs
+++ b/rpc/src/client.rs
@@ -10,7 +10,6 @@ pub use self::native::Client;
 #[cfg(not(target_arch = "wasm32"))]
 mod native {
     use std::fmt;
-    use std::marker::Send;
     use std::result::Result as StdResult;
 
     use crate::{Error, Result};

--- a/rpc/src/error.rs
+++ b/rpc/src/error.rs
@@ -6,6 +6,9 @@ pub enum Error {
     #[error("Token contains invalid characters: {0}")]
     InvalidCharactersInToken(#[from] http::header::InvalidHeaderValue),
 
+    #[error("Protocol not supported or missing: {0}")]
+    ProtocolNotSupported(String),
+
     #[error(transparent)]
     JsonRpc(#[from] jsonrpsee::core::Error),
 }

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -8,6 +8,8 @@ mod share;
 mod state;
 
 pub use crate::blob::BlobClient;
+#[cfg(not(target_arch = "wasm32"))]
+pub use crate::client::Client;
 pub use crate::error::{Error, Result};
 pub use crate::header::HeaderClient;
 #[cfg(feature = "p2p")]

--- a/rpc/tests/utils/client.rs
+++ b/rpc/tests/utils/client.rs
@@ -9,8 +9,7 @@ use jsonrpsee::core::client::ClientT;
 use jsonrpsee::core::Error;
 use tokio::sync::{Mutex, MutexGuard};
 
-const WS_URL: &str = "ws://localhost:26658";
-const HTTP_URL: &str = "http://localhost:26658";
+const CELESTIA_RPC_URL: &str = "ws://localhost:26658";
 
 async fn write_lock() -> MutexGuard<'static, ()> {
     static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
@@ -41,24 +40,8 @@ fn env_or(var_name: &str, or_value: &str) -> String {
 pub async fn new_test_client(auth_level: AuthLevel) -> Result<Client> {
     let _ = dotenvy::dotenv();
     let token = token_from_env(auth_level)?;
-    let url = env_or("CELESTIA_RPC_URL", WS_URL);
+    let url = env_or("CELESTIA_RPC_URL", CELESTIA_RPC_URL);
 
-    assert!(url.starts_with("ws://"));
-    let client = Client::new(&url, token.as_deref()).await?;
-
-    // minimum 2 blocks
-    client.header_wait_for_height(2).await?;
-
-    Ok(client)
-}
-
-// This can be used if you want to inspect the requests from `mitmproxy`.
-pub async fn new_test_client_http(auth_level: AuthLevel) -> Result<Client> {
-    let _ = dotenvy::dotenv();
-    let token = token_from_env(auth_level)?;
-    let url = env_or("CELESTIA_RPC_URL_HTTP", HTTP_URL);
-
-    assert!(url.starts_with("http://"));
     let client = Client::new(&url, token.as_deref()).await?;
 
     // minimum 2 blocks

--- a/rpc/tests/utils/client.rs
+++ b/rpc/tests/utils/client.rs
@@ -2,13 +2,11 @@ use std::env;
 use std::sync::OnceLock;
 
 use anyhow::Result;
-use celestia_rpc::client::{new_http, new_websocket};
+use celestia_rpc::client::{HttpClient, WsClient};
 use celestia_rpc::prelude::*;
 use celestia_types::{blob::SubmitOptions, Blob};
 use jsonrpsee::core::client::ClientT;
 use jsonrpsee::core::Error;
-use jsonrpsee::http_client::HttpClient;
-use jsonrpsee::ws_client::WsClient;
 use tokio::sync::{Mutex, MutexGuard};
 
 const WS_URL: &str = "ws://localhost:26658";
@@ -45,7 +43,7 @@ pub async fn new_test_client(auth_level: AuthLevel) -> Result<WsClient> {
     let token = token_from_env(auth_level)?;
     let url = env_or("CELESTIA_RPC_URL", WS_URL);
 
-    let client = new_websocket(&url, token.as_deref()).await?;
+    let client = WsClient::new(&url, token.as_deref()).await?;
 
     // minimum 2 blocks
     client.header_wait_for_height(2).await?;
@@ -59,7 +57,7 @@ pub async fn new_test_client_http(auth_level: AuthLevel) -> Result<HttpClient> {
     let token = token_from_env(auth_level)?;
     let url = env_or("CELESTIA_RPC_URL", HTTP_URL);
 
-    let client = new_http(&url, token.as_deref())?;
+    let client = HttpClient::new(&url, token.as_deref())?;
 
     // minimum 2 blocks
     client.header_wait_for_height(2).await?;


### PR DESCRIPTION
An alternative way to fix #100 that avoids re-exporting jsonrpsee directly